### PR TITLE
Fix #1: build error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,9 +7,9 @@ pkgdesc='Hides the titlebar when a window is maximized in Gnome/Cinnamon'
 arch=('any')
 depends=('python-xlib')
 url='https://github.com/memeplex/maximal'
-source=("git+$url.git")
+source=("maximal-git::git+$url.git")
 md5sums=('SKIP')
 
 package() {
-    install -D $srcdir/maximal/maximal $pkgdir/usr/bin/maximal
+    install -D $srcdir/maximal-git/maximal $pkgdir/usr/bin/maximal
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,6 +6,7 @@ pkgrel=1
 pkgdesc='Hides the titlebar when a window is maximized in Gnome/Cinnamon'
 arch=('any')
 depends=('python-xlib')
+makedepends=('git')
 url='https://github.com/memeplex/maximal'
 source=("maximal-git::git+$url.git")
 md5sums=('SKIP')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,9 +5,9 @@ pkgver=20180705
 pkgrel=1
 pkgdesc='Hides the titlebar when a window is maximized in Gnome/Cinnamon'
 arch=('any')
+url='https://github.com/memeplex/maximal'
 depends=('python-xlib')
 makedepends=('git')
-url='https://github.com/memeplex/maximal'
 source=("maximal-git::git+$url.git")
 md5sums=('SKIP')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=maximal
 pkgver=20180705
-pkgrel=1
+pkgrel=2
 pkgdesc='Hides the titlebar when a window is maximized in Gnome/Cinnamon'
 arch=('any')
 url='https://github.com/memeplex/maximal'


### PR DESCRIPTION
Having the package, the sources (repository) and the executable all named `maximal` seems to confuse `makepkg`. Renaming the sources makes it work.

Also cleanups.