### PR TITLE
Add instructions for systemd service

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,11 +1,13 @@
 pkgbase = maximal
 	pkgdesc = Hides the titlebar when a window is maximized in Gnome/Cinnamon
 	pkgver = 20180705
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/memeplex/maximal
 	arch = any
+	makedepends = git
 	depends = python-xlib
-	source = git+https://github.com/memeplex/${pkgname}.git
+	source = maximal-git::git+https://github.com/memeplex/maximal.git
+	md5sums = SKIP
 
 pkgname = maximal
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This fork is abandonned.** I could never find the time to make it work with recent versions of GNOME, much less under Wayland.
+
 # maximal
 
 A minimal utility that hides the titlebar when a window is maximized in Gnome (and soon also in Cinnamon due to https://github.com/linuxmint/Cinnamon/issues/7681).

--- a/README.md
+++ b/README.md
@@ -22,23 +22,50 @@ You can set a whitelist and/or a blacklist of patterns by exporting the environm
 
 ## Installation
 
-If you're on Arch or an Arch-based distro (like Manjaro) you can install `maximal` from the AUR:
+### Install with `pip`
 
-`yaourt -S maximal`
+For system-level installation:
 
-Otherwise use `pip`:
+    pip install git+https://github.com/memeplex/maximal.git
 
-* For system-level installation run `pip install git+https://github.com/memeplex/maximal.git`
+For user-level installation:
 
-* For user-level installation run `pip install --user git+https://github.com/memeplex/maximal.git`
+    pip install --user git+https://github.com/memeplex/maximal.git
 
-Then add something like the following to your `~/.xprofile` and start a new session:
+### Install from AUR (Archlinux & Arch-based distros)
+
+    yaourt -S maximal
+
+### Autostart using xprofile
+
+Add something like the following to your `~/.xprofile` and start a new session:
 
 ```
 export MAXIMAL_WHITELIST=...
 export MAXIMAL_BLACKLIST=...
 maximal &
 ```
+
+### Autostart using systemd
+
+Create a file `~/.local/share/systemd/user/maximal.service` with the following content:
+
+    [Unit]
+    Description=Removes title bar from maximized windows
+
+    [Service]
+    Type=simple
+    ExecStart=maximal
+    TimeoutStartSec=0
+    Restart=on-success
+
+    [Install]
+    WantedBy=default.target
+
+Then enable and start the service with
+
+    systemctl --user enable maximal.service
+    systemctl --user start maximal.service
 
 ## TODO
 


### PR DESCRIPTION
Ideally the service should be installed from AUR, but this is a start.